### PR TITLE
Fix markdown editor download links rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,36 @@
 
 ## 简介
 
-一款为Halo提供云盘下载链接卡片展示的插件，支持默认编辑器中可视化插入网盘链接。
+一款为Halo提供云盘下载链接卡片展示的插件，支持默认编辑器中可视化插入网盘链接，也支持在其他 Markdown / HTML 编辑器中通过自定义标签插入下载卡片。
+
+## 其他编辑器用法
+
+如果你使用的不是 Halo 默认编辑器，可以在文章或页面中插入以下 HTML：
+
+```html
+<download-links>
+  <download-link
+    source="百度云网盘"
+    filename="示例文件.zip"
+    url="https://example.com/file.zip"
+    code="abcd"
+  ></download-link>
+  <download-link
+    source="夸克网盘"
+    filename="备用下载地址"
+    url="https://example.com/backup.zip"
+  ></download-link>
+</download-links>
+```
+
+字段说明：
+
+- `source`：下载来源名称，和插件设置里的下载来源名称一致时会自动匹配图标
+- `filename`：下载文件名或展示标题
+- `url`：下载地址，必填
+- `code`：提取码，可选
+
+如果 Markdown 编辑器将上述标签转义为 `&lt;download-links&gt;` 形式，插件也会在前台渲染时识别并转换。
 
 ## 展示
 <img style="width: 400px !important; height: auto; object-fit: contain;" src="https://github.com/user-attachments/assets/c33ceb01-fbe4-4540-a902-d7ef4995478d" />

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,12 @@ repositories {
 dependencies {
     implementation platform('run.halo.tools.platform:plugin:2.24.0')
     compileOnly 'run.halo.app:api'
+
+    testImplementation 'run.halo.app:api'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'io.projectreactor:reactor-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 test {

--- a/src/main/java/site/muyin/downloadlinks/handle/DownloadLinksRenderer.java
+++ b/src/main/java/site/muyin/downloadlinks/handle/DownloadLinksRenderer.java
@@ -27,6 +27,11 @@ public class DownloadLinksRenderer {
 
     private static final Pattern TAG_PATTERN = Pattern.compile("(?s)<download-links\\b([^>]*)>.*?</download-links>");
     private static final Pattern DATA_LINKS_PATTERN = Pattern.compile("data-links\\s*=\\s*\"(.*?)\"");
+    private static final Pattern DOWNLOAD_LINK_PATTERN = Pattern.compile("(?s)<download-link\\b([^>]*)/?>.*?</download-link>|<download-link\\b([^>]*)/>");
+    private static final Pattern ATTRIBUTE_PATTERN = Pattern.compile("([\\w:-]+)\\s*=\\s*(\"([^\"]*)\"|'([^']*)')");
+    private static final Pattern ESCAPED_DOWNLOAD_LINKS_TAG_PATTERN = Pattern.compile("&lt;(/?download-links\\b.*?)&gt;", Pattern.DOTALL);
+    private static final Pattern ESCAPED_DOWNLOAD_LINK_TAG_PATTERN = Pattern.compile("&lt;(/?download-link\\b.*?)&gt;", Pattern.DOTALL);
+    private static final Pattern DOWNLOAD_LINK_TAG_PATTERN = Pattern.compile("<(/?download-link\\b[^>]*)>", Pattern.DOTALL);
     private static final String STYLE_ID = "tools-download-links-style";
     private static final String STYLE_MARKER = "<!-- " + STYLE_ID + " -->";
 
@@ -37,10 +42,11 @@ public class DownloadLinksRenderer {
         if (isBlank(html)) {
             return Mono.just(html);
         }
-        if (!TAG_PATTERN.matcher(html).find()) {
+        String normalizedHtml = unescapeDownloadLinkTags(html);
+        if (!TAG_PATTERN.matcher(normalizedHtml).find()) {
             return Mono.just(html);
         }
-        boolean needsStyle = !html.contains(STYLE_ID) && !html.contains(STYLE_MARKER);
+        boolean needsStyle = !normalizedHtml.contains(STYLE_ID) && !normalizedHtml.contains(STYLE_MARKER);
 
         return settingFetcher.fetch(DownloadSetting.GROUP, DownloadSetting.class)
                 .defaultIfEmpty(new DownloadSetting())
@@ -49,20 +55,10 @@ public class DownloadLinksRenderer {
                     String styleBlock = needsStyle ? buildStyleBlock(downloadSetting) : "";
 
                     final boolean[] styleInjected = {false};
-                    String result = replaceAll(html, TAG_PATTERN, matcher -> {
+                    String result = replaceAll(normalizedHtml, TAG_PATTERN, matcher -> {
                         String attrs = matcher.group(1);
-                        String data = extractGroup(attrs, DATA_LINKS_PATTERN, 1);
-                        if (data == null) {
-                            return "";
-                        }
-                        data = unescapeHtml(data);
-                        List<Map<String, Object>> links;
-                        try {
-                            links = objectMapper.readValue(data, new TypeReference<>() {
-                            });
-                        } catch (Exception e) {
-                            links = Collections.emptyList();
-                        }
+                        String tagContent = matcher.group();
+                        List<Map<String, Object>> links = parseLinks(attrs, tagContent);
                         String htmlContent = buildHtml(links, sourceIconMap);
                         if (needsStyle && !styleInjected[0] && !links.isEmpty()) {
                             styleInjected[0] = true;
@@ -70,15 +66,96 @@ public class DownloadLinksRenderer {
                         }
                         return htmlContent;
                     });
-                    if (needsStyle && !styleInjected[0]) {
-                        if (result.contains("</head>")) {
-                            result = result.replace("</head>", styleBlock + "\n</head>");
-                        } else {
-                            result = styleBlock + "\n" + result;
-                        }
-                    }
                     return result;
                 });
+    }
+
+    public Mono<String> renderContent(String raw, String content) {
+        return render(content)
+                .flatMap(renderedContent -> {
+                    if (hasRenderedBlock(renderedContent) || !containsDownloadLinks(raw)) {
+                        return Mono.just(renderedContent);
+                    }
+                    String rawBlocks = extractDownloadLinkBlocks(raw);
+                    return render(rawBlocks).map(renderedBlocks ->
+                            isBlank(renderedBlocks) ? renderedContent : appendHtml(renderedContent, renderedBlocks)
+                    );
+                });
+    }
+
+    private boolean containsDownloadLinks(String html) {
+        if (isBlank(html)) {
+            return false;
+        }
+        return TAG_PATTERN.matcher(unescapeDownloadLinkTags(html)).find();
+    }
+
+    private boolean hasRenderedBlock(String html) {
+        return isNotBlank(html) && html.contains("tools-download-links");
+    }
+
+    private String extractDownloadLinkBlocks(String html) {
+        if (isBlank(html)) {
+            return "";
+        }
+        Matcher matcher = TAG_PATTERN.matcher(unescapeDownloadLinkTags(html));
+        StringBuilder blocks = new StringBuilder();
+        while (matcher.find()) {
+            blocks.append(matcher.group()).append("\n");
+        }
+        return blocks.toString();
+    }
+
+    private String appendHtml(String content, String htmlToAppend) {
+        if (isBlank(content)) {
+            return htmlToAppend;
+        }
+        return content.stripTrailing() + "\n" + htmlToAppend;
+    }
+
+    private String unescapeDownloadLinkTags(String html) {
+        String normalized = replaceAll(html, ESCAPED_DOWNLOAD_LINKS_TAG_PATTERN, matcher -> "<" + matcher.group(1) + ">");
+        normalized = replaceAll(normalized, ESCAPED_DOWNLOAD_LINK_TAG_PATTERN, matcher -> "<" + matcher.group(1) + ">");
+        return replaceAll(normalized, DOWNLOAD_LINK_TAG_PATTERN,
+                matcher -> "<" + unescapeHtml(matcher.group(1)) + ">");
+    }
+
+    private List<Map<String, Object>> parseLinks(String attrs, String tagContent) {
+        String data = extractGroup(attrs, DATA_LINKS_PATTERN, 1);
+        if (data != null) {
+            data = unescapeHtml(data);
+            try {
+                return objectMapper.readValue(data, new TypeReference<>() {
+                });
+            } catch (Exception e) {
+                return Collections.emptyList();
+            }
+        }
+        return parseDownloadLinkChildren(tagContent);
+    }
+
+    private List<Map<String, Object>> parseDownloadLinkChildren(String tagContent) {
+        List<Map<String, Object>> links = new java.util.ArrayList<>();
+        Matcher matcher = DOWNLOAD_LINK_PATTERN.matcher(tagContent);
+        while (matcher.find()) {
+            String attrs = matcher.group(1) != null ? matcher.group(1) : matcher.group(2);
+            Map<String, Object> link = parseAttributes(attrs);
+            if (isNotBlank(str(link.get("url")))) {
+                links.add(link);
+            }
+        }
+        return links;
+    }
+
+    private Map<String, Object> parseAttributes(String attrs) {
+        Map<String, Object> result = new java.util.HashMap<>();
+        Matcher matcher = ATTRIBUTE_PATTERN.matcher(attrs);
+        while (matcher.find()) {
+            String name = matcher.group(1);
+            String value = matcher.group(3) != null ? matcher.group(3) : matcher.group(4);
+            result.put(name, unescapeHtml(value));
+        }
+        return result;
     }
 
     private Map<String, String> buildSourceIconMap(DownloadSetting downloadSetting) {

--- a/src/main/java/site/muyin/downloadlinks/handle/PostDownloadLinksContentHandler.java
+++ b/src/main/java/site/muyin/downloadlinks/handle/PostDownloadLinksContentHandler.java
@@ -17,7 +17,7 @@ public class PostDownloadLinksContentHandler implements ReactivePostContentHandl
         String content = postContent.getContent();
 
         return renderer.render(raw)
-                .flatMap(renderedRaw -> renderer.render(content)
+                .flatMap(renderedRaw -> renderer.renderContent(raw, content)
                         .map(renderedContent -> {
                             postContent.setRaw(renderedRaw);
                             postContent.setContent(renderedContent);
@@ -25,5 +25,4 @@ public class PostDownloadLinksContentHandler implements ReactivePostContentHandl
                         }));
     }
 }
-
 

--- a/src/main/java/site/muyin/downloadlinks/handle/SinglePageDownloadLinksContentHandler.java
+++ b/src/main/java/site/muyin/downloadlinks/handle/SinglePageDownloadLinksContentHandler.java
@@ -17,7 +17,7 @@ public class SinglePageDownloadLinksContentHandler implements ReactiveSinglePage
         String content = singlePageContent.getContent();
 
         return renderer.render(raw)
-                .flatMap(renderedRaw -> renderer.render(content)
+                .flatMap(renderedRaw -> renderer.renderContent(raw, content)
                         .map(renderedContent -> {
                             singlePageContent.setRaw(renderedRaw);
                             singlePageContent.setContent(renderedContent);
@@ -25,6 +25,5 @@ public class SinglePageDownloadLinksContentHandler implements ReactiveSinglePage
                         }));
     }
 }
-
 
 

--- a/src/test/java/site/muyin/downloadlinks/handle/DownloadLinksRendererTest.java
+++ b/src/test/java/site/muyin/downloadlinks/handle/DownloadLinksRendererTest.java
@@ -1,0 +1,206 @@
+package site.muyin.downloadlinks.handle;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import run.halo.app.plugin.ReactiveSettingFetcher;
+import site.muyin.downloadlinks.setting.DownloadSetting;
+import tools.jackson.databind.JsonNode;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DownloadLinksRendererTest {
+
+    private final DownloadLinksRenderer renderer = new DownloadLinksRenderer(
+            new ObjectMapper(),
+            new TestSettingFetcher()
+    );
+
+    @Test
+    void rendersDownloadLinkChildrenForExternalEditors() {
+        String html = """
+                <article>
+                  <download-links>
+                    <download-link source="百度网盘" filename="示例文件.zip" url="https://example.com/file.zip" code="abcd"></download-link>
+                  </download-links>
+                </article>
+                """;
+
+        StepVerifier.create(renderer.render(html))
+                .assertNext(rendered -> {
+                    assertThat(rendered).contains("tools-download-links");
+                    assertThat(rendered).contains("示例文件.zip");
+                    assertThat(rendered).contains("百度网盘");
+                    assertThat(rendered).contains("提取码: abcd");
+                    assertThat(rendered).contains("https://example.com/file.zip");
+                    assertThat(rendered).doesNotContain("<download-link");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void rendersDownloadLinksWhenMarkdownWrapsChildrenInParagraphs() {
+        String html = """
+                <p><download-links></p>
+                <p><download-link
+                    source="百度网盘"
+                    filename="示例文件.zip"
+                    url="https://example.com/file.zip"
+                    code="abcd"
+                  ></download-link><br>
+                  <download-link
+                    source="夸克网盘"
+                    filename="备用下载地址"
+                    url="https://example.com/backup.zip"
+                  ></download-link></p>
+                <p></download-links></p>
+                """;
+
+        StepVerifier.create(renderer.render(html))
+                .assertNext(rendered -> {
+                    assertThat(rendered).contains("tools-download-links");
+                    assertThat(rendered).contains("示例文件.zip");
+                    assertThat(rendered).contains("备用下载地址");
+                    assertThat(rendered).contains("https://example.com/file.zip");
+                    assertThat(rendered).contains("https://example.com/backup.zip");
+                    assertThat(rendered).doesNotContain("<download-links");
+                    assertThat(rendered).doesNotContain("<download-link");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void rendersDownloadLinksEscapedByMarkdownRenderer() {
+        String html = """
+                <p>&lt;download-links&gt;
+                  &lt;download-link
+                    source=&quot;百度网盘&quot;
+                    filename=&quot;示例文件.zip&quot;
+                    url=&quot;https://example.com/file.zip&quot;
+                    code=&quot;abcd&quot;
+                  &gt;&lt;/download-link&gt;
+                &lt;/download-links&gt;</p>
+                """;
+
+        StepVerifier.create(renderer.render(html))
+                .assertNext(rendered -> {
+                    assertThat(rendered).contains("tools-download-links");
+                    assertThat(rendered).contains("示例文件.zip");
+                    assertThat(rendered).contains("https://example.com/file.zip");
+                    assertThat(rendered).doesNotContain("&lt;download-links");
+                    assertThat(rendered).doesNotContain("&lt;download-link");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void restoresDownloadLinksFromRawWhenMarkdownDropsCustomTags() {
+        String content = """
+                <p>11</p>
+
+                  
+                  
+                """;
+        String raw = """
+                11
+
+                <download-links>
+                  <download-link
+                    source="百度网盘"
+                    filename="示例文件.zip"
+                    url="https://example.com/file.zip"
+                    code="abcd"
+                  ></download-link>
+                  <download-link
+                    source="夸克网盘"
+                    filename="备用下载地址"
+                    url="https://example.com/backup.zip"
+                  ></download-link>
+                </download-links>
+                """;
+
+        StepVerifier.create(renderer.renderContent(raw, content))
+                .assertNext(rendered -> {
+                    assertThat(rendered).contains("<p>11</p>");
+                    assertThat(rendered).contains("tools-download-links");
+                    assertThat(rendered).contains("示例文件.zip");
+                    assertThat(rendered).contains("备用下载地址");
+                    assertThat(rendered).contains("https://example.com/file.zip");
+                    assertThat(rendered).contains("https://example.com/backup.zip");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void keepsRenderingDataLinksFromDefaultEditor() {
+        String html = """
+                <download-links data-links="[{&quot;source&quot;:&quot;百度网盘&quot;,&quot;filename&quot;:&quot;默认编辑器.zip&quot;,&quot;url&quot;:&quot;https://example.com/default.zip&quot;,&quot;code&quot;:&quot;efgh&quot;}]"></download-links>
+                """;
+
+        StepVerifier.create(renderer.render(html))
+                .assertNext(rendered -> {
+                    assertThat(rendered).contains("tools-download-links");
+                    assertThat(rendered).contains("默认编辑器.zip");
+                    assertThat(rendered).contains("提取码: efgh");
+                    assertThat(rendered).contains("https://example.com/default.zip");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void skipsDownloadLinkChildrenWithoutUrl() {
+        String html = """
+                <download-links>
+                  <download-link source="百度网盘" filename="缺少链接"></download-link>
+                </download-links>
+                """;
+
+        StepVerifier.create(renderer.render(html))
+                .assertNext(rendered -> {
+                    assertThat(rendered).doesNotContain("tools-download-links__item");
+                    assertThat(rendered).doesNotContain("缺少链接");
+                })
+                .verifyComplete();
+    }
+
+    @SuppressWarnings("removal")
+    private static class TestSettingFetcher implements ReactiveSettingFetcher {
+
+        @Override
+        public <T> Mono<T> fetch(String group, Class<T> clazz) {
+            DownloadSetting setting = new DownloadSetting()
+                    .setLightModeSelector(".light")
+                    .setDarkModeSelector(".dark")
+                    .setDownloadSourceList(List.of(
+                            new DownloadSetting.DownloadSource()
+                                    .setName("百度网盘")
+                                    .setIcon("/plugins/download-links/assets/static/icon/baidu.png")
+                    ));
+            return Mono.just(clazz.cast(setting));
+        }
+
+        @Override
+        public Mono<com.fasterxml.jackson.databind.JsonNode> get(String group) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<JsonNode> getSettingValue(String group) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<Map<String, com.fasterxml.jackson.databind.JsonNode>> getValues() {
+            return Mono.just(Map.of());
+        }
+
+        @Override
+        public Mono<Map<String, JsonNode>> getSettingValues() {
+            return Mono.just(Map.of());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- support external Markdown/HTML editors with nested `<download-link>` children inside `<download-links>`
- restore download link blocks from raw Markdown when Halo's rendered content drops custom tags
- keep default editor `data-links` rendering compatible and document the custom tag usage

## Tests
- `./gradlew test`
- verified `http://localhost:8686/archives/cs` outputs `tools-download-links` after plugin reload

Fixes #3